### PR TITLE
Update README with default value for --max-processes

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ The behaviour of gnaf-loader can be controlled by specifying various command lin
 if you intend to utilise the raw GNAF tables as anything more then a temporary import step. Note that the final processed tables will always have appropriate
 primary and foreign keys set.
 * `--raw-unlogged` creates unlogged raw GNAF tables, speeding up the import. Defaults to off. Only specify this option if you don't care about the raw data tables after the import - they will be lost if the server crashes!
-* `--max-processes` specifies the maximum number of parallel processes to use for the data load. Set this to the number of cores on the Postgres server minus 2, but limit to 12 if 16+ cores - there is minimal benefit beyond 12. Defaults to 3.
+* `--max-processes` specifies the maximum number of parallel processes to use for the data load. Set this to the number of cores on the Postgres server minus 2, but limit to 12 if 16+ cores - there is minimal benefit beyond 12. Defaults to 4.
 * `--no-boundary-tag` DO NOT tag all addresses with some of the key admin boundary IDs for creating aggregates and choropleth maps.
 
 ### Example Command Line Arguments


### PR DESCRIPTION
bringing the README in line with the value set in code https://github.com/minus34/gnaf-loader/commit/61b7c2153c8550943208b5eee544a1b5e3d5f0cf#diff-36770ff4fa240290e2636756323035ef