### PR TITLE
Bugfix: Remove hard-coded schema name

### DIFF
--- a/postgres-scripts/03-02-reference-populate-localities.sql
+++ b/postgres-scripts/03-02-reference-populate-localities.sql
@@ -10,10 +10,10 @@ SELECT loc.locality_pid,
        aut.name AS locality_class,
        loc.gnaf_reliability_code,
 	     st_setsrid(st_makepoint(avg(pnt.longitude), avg(pnt.latitude)), 4283) AS geom
-FROM raw_gnaf_202008.locality AS loc
-INNER JOIN raw_gnaf_202008.state AS st ON loc.state_pid = st.state_pid
-INNER JOIN raw_gnaf_202008.locality_class_aut AS aut ON loc.locality_class_code = aut.code
-LEFT OUTER JOIN raw_gnaf_202008.locality_point AS pnt ON loc.locality_pid = pnt.locality_pid
+FROM raw_gnaf.locality AS loc
+INNER JOIN raw_gnaf.state AS st ON loc.state_pid = st.state_pid
+INNER JOIN raw_gnaf.locality_class_aut AS aut ON loc.locality_class_code = aut.code
+LEFT OUTER JOIN raw_gnaf.locality_point AS pnt ON loc.locality_pid = pnt.locality_pid
 GROUP BY loc.locality_pid,
        loc.locality_name,
        loc.primary_postcode,


### PR DESCRIPTION
The schema name "raw_gnaf_202008" was hardcoded which resulted in the following error when 
specifying a different schema name via the --raw-gnaf-schema argument:

File "gnaf-loader-master\load-gnaf.py", line 616, in create_reference_tables
pg_cur.execute(psma.open_sql_file("03-02-reference-populate-localities.sql", settings))
psycopg2.errors.UndefinedTable: relation "raw_gnaf_202008.locality" does not exist